### PR TITLE
add Java module configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,18 @@
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>21.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>20</version>
+            <version>21.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>21.0.1</version>
         </dependency>
     </dependencies>
 
@@ -65,8 +75,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -132,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module com.brunomnsilva.smartgraph {
+    requires javafx.controls;
+    requires javafx.graphics;
+    requires javafx.base;
+    requires java.logging;
+    
+    exports com.brunomnsilva.smartgraph;
+    exports com.brunomnsilva.smartgraph.containers;
+    exports com.brunomnsilva.smartgraph.graph;
+    exports com.brunomnsilva.smartgraph.graphview;
+}


### PR DESCRIPTION
Makes it work with modern (OK, Java 11+) configurations.

I hit some javadoc errors with the upgrade, so bumped the plugin for that too.